### PR TITLE
Release 2.0-rc5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
         <configuration>
           <gen>${basedir}/gen</gen>
           <!--jsInteropMode>JS</jsInteropMode-->
-          <incremental>true</incremental>
+          <incremental>false</incremental>
           <generateJsInteropExports>true</generateJsInteropExports>
         </configuration>
         <executions>

--- a/src/main/java/gwt/material/design/jquery/JQuery.gwt.xml
+++ b/src/main/java/gwt/material/design/jquery/JQuery.gwt.xml
@@ -25,9 +25,7 @@
     
     <source path='client' />
 
-    <set-property name="user.agent" value="safari"/>
-    <set-property name="user.agent" value="gecko1_8" />
-    <set-property name="user.agent" value="ie10"/>
+    <set-property name="user.agent" value="ie10, gecko1_8, safari"/>
     <set-configuration-property name="user.agent.runtimeWarning" value="false"/>
 
     <entry-point class="gwt.material.design.jquery.client.JQueryEntryPoint" />

--- a/src/main/java/gwt/material/design/jscore/JSCore.gwt.xml
+++ b/src/main/java/gwt/material/design/jscore/JSCore.gwt.xml
@@ -23,9 +23,7 @@
     <inherits name='com.google.gwt.user.User' />
     <source path='client' />
 
-    <set-property name="user.agent" value="safari"/>
-    <set-property name="user.agent" value="gecko1_8" />
-    <set-property name="user.agent" value="ie10"/>
+    <set-property name="user.agent" value="ie10, gecko1_8, safari"/>
     <set-configuration-property name="user.agent.runtimeWarning" value="false"/>
 
     <entry-point class='gwt.material.design.jscore.client.JSCoreEntryPoint'/>


### PR DESCRIPTION
Note : There is an iteration on version number to be uniform to all GMD Projects now we will make use of 2.0-rc5 instead of 1.0-rc5. 

