### PR TITLE
Release 2.0-rc6

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@ JQuery interface maintained by GWT Material Design.
 Documentation on the JQuery can be found here: https://api.jquery.com/
 
 ## Maven
-Current Version 2.0-rc5
+Current Version 2.0-rc6
 ```xml
 <dependency>
     <groupId>com.github.gwtmaterialdesign</groupId>
     <artifactId>gwt-material-jquery</artifactId>
-    <version>2.0-rc5</version>
+    <version>2.0-rc6</version>
 </dependency>
 ```
 Snapshot Version 2.0-SNAPSHOT

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 <img src="http://i.imgur.com/5GxyXx6.png" />
+
 ## GWT Material JQuery
 
 [![Build Status](https://travis-ci.org/GwtMaterialDesign/gwt-material-jquery.svg?branch=master)](https://travis-ci.org/GwtMaterialDesign/gwt-material-jquery)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 <img src="http://i.imgur.com/5GxyXx6.png" />
-# GWT Material JQuery [![Build Status](https://travis-ci.org/GwtMaterialDesign/gwt-material-jquery.svg?branch=master)](https://travis-ci.org/GwtMaterialDesign/gwt-material-jquery)
+# GWT Material JQuery
+
+[![Build Status](https://travis-ci.org/GwtMaterialDesign/gwt-material-jquery.svg?branch=master)](https://travis-ci.org/GwtMaterialDesign/gwt-material-jquery)
 
 JQuery interface maintained by GWT Material Design.
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 <img src="http://i.imgur.com/5GxyXx6.png" />
-#GWT Material JQuery
+## GWT Material JQuery
 
 [![Build Status](https://travis-ci.org/GwtMaterialDesign/gwt-material-jquery.svg?branch=master)](https://travis-ci.org/GwtMaterialDesign/gwt-material-jquery)
 
 JQuery interface maintained by GWT Material Design.
 
-##Documentation
+## Documentation
 
 Documentation on the JQuery can be found here: https://api.jquery.com/
 
-##Maven
+## Maven
 Current Version 2.0-rc6
 ```xml
 <dependency>
@@ -27,7 +27,7 @@ Snapshot Version 2.0-SNAPSHOT
 </dependency>
 ```
 
-##Usage
+## Usage
 Ensure you have JQuery loaded before this library is inherited.
 This is handled by GMD if you yare using `GwtMaterialWithJQuery` GMD module.
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 <img src="http://i.imgur.com/5GxyXx6.png" />
-# GWT Material JQuery
+#GWT Material JQuery
 
 [![Build Status](https://travis-ci.org/GwtMaterialDesign/gwt-material-jquery.svg?branch=master)](https://travis-ci.org/GwtMaterialDesign/gwt-material-jquery)
 
 JQuery interface maintained by GWT Material Design.
 
-## Documentation
+##Documentation
 
 Documentation on the JQuery can be found here: https://api.jquery.com/
 
-## Maven
+##Maven
 Current Version 2.0-rc6
 ```xml
 <dependency>
@@ -27,7 +27,7 @@ Snapshot Version 2.0-SNAPSHOT
 </dependency>
 ```
 
-## Usage
+##Usage
 Ensure you have JQuery loaded before this library is inherited.
 This is handled by GMD if you yare using `GwtMaterialWithJQuery` GMD module.
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>com.github.gwtmaterialdesign</groupId>
   <artifactId>gwt-material-jquery</artifactId>
   <packaging>jar</packaging>
-  <version>2.0-rc5</version>
+  <version>2.0-SNAPSHOT</version>
 
   <properties>
     <gwt.version>2.8.0</gwt.version>
@@ -39,7 +39,7 @@
     <connection>scm:git:git@github.com:GwtMaterialDesign/gwt-material-jquery.git</connection>
     <developerConnection>scm:git:git@github.com:GwtMaterialDesign/gwt-material-jquery.git</developerConnection>
     <url>http://github.com/GwtMaterialDesign/gwt-material-jquery</url>
-    <tag>v2.0-rc5</tag>
+    <tag>v2.0-SNAPSHOT</tag>
   </scm>
 
   <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,6 @@
 
   <properties>
     <gwt.version>2.8.1</gwt.version>
-    <gwt.plugin.version>2.8.0</gwt.plugin.version>
 
     <jscore.version>1.0</jscore.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -104,7 +103,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>gwt-maven-plugin</artifactId>
-        <version>${gwt.plugin.version}</version>
+        <version>${gwt.version}</version>
         <configuration>
           <gen>${basedir}/gen</gen>
           <!--jsInteropMode>JS</jsInteropMode-->

--- a/pom.xml
+++ b/pom.xml
@@ -96,8 +96,8 @@
         <version>3.1</version>
         <inherited>true</inherited>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   <version>2.0-SNAPSHOT</version>
 
   <properties>
-    <gwt.version>2.8.0</gwt.version>
+    <gwt.version>2.8.1</gwt.version>
     <gwt.plugin.version>2.8.0</gwt.plugin.version>
 
     <jscore.version>1.0</jscore.version>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>com.github.gwtmaterialdesign</groupId>
   <artifactId>gwt-material-jquery</artifactId>
   <packaging>jar</packaging>
-  <version>2.0-SNAPSHOT</version>
+  <version>2.0-rc6</version>
 
   <properties>
     <gwt.version>2.8.1</gwt.version>
@@ -39,7 +39,7 @@
     <connection>scm:git:git@github.com:GwtMaterialDesign/gwt-material-jquery.git</connection>
     <developerConnection>scm:git:git@github.com:GwtMaterialDesign/gwt-material-jquery.git</developerConnection>
     <url>http://github.com/GwtMaterialDesign/gwt-material-jquery</url>
-    <tag>v2.0-SNAPSHOT</tag>
+    <tag>v2.0-rc6</tag>
   </scm>
 
   <distributionManagement>

--- a/src/main/java/gwt/material/design/jquery/JQuery.gwt.xml
+++ b/src/main/java/gwt/material/design/jquery/JQuery.gwt.xml
@@ -3,7 +3,7 @@
   #%L
   GwtMaterial
   %%
-  Copyright (C) 2015 - 2016 GwtMaterialDesign
+  Copyright (C) 2015 - 2017 GwtMaterialDesign
   %%
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/src/main/java/gwt/material/design/jquery/client/JQueryEntryPoint.java
+++ b/src/main/java/gwt/material/design/jquery/client/JQueryEntryPoint.java
@@ -19,7 +19,7 @@ package gwt.material.design.jquery.client;
  * #%L
  * GwtMaterial
  * %%
- * Copyright (C) 2015 - 2016 GwtMaterialDesign
+ * Copyright (C) 2015 - 2017 GwtMaterialDesign
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/gwt/material/design/jquery/client/api/AnimateOptions.java
+++ b/src/main/java/gwt/material/design/jquery/client/api/AnimateOptions.java
@@ -4,7 +4,7 @@ package gwt.material.design.jquery.client.api;
  * #%L
  * GwtMaterial
  * %%
- * Copyright (C) 2015 - 2016 GwtMaterialDesign
+ * Copyright (C) 2015 - 2017 GwtMaterialDesign
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/gwt/material/design/jquery/client/api/AnimateOptions.java
+++ b/src/main/java/gwt/material/design/jquery/client/api/AnimateOptions.java
@@ -31,7 +31,7 @@ import jsinterop.annotations.JsType;
 /**
  * @author Ben Dol
  */
-@JsType
+@JsType(isNative = true)
 public class AnimateOptions {
 
     @JsProperty public native double getDuration();

--- a/src/main/java/gwt/material/design/jquery/client/api/Event.java
+++ b/src/main/java/gwt/material/design/jquery/client/api/Event.java
@@ -4,7 +4,7 @@ package gwt.material.design.jquery.client.api;
  * #%L
  * GwtMaterial
  * %%
- * Copyright (C) 2015 - 2016 GwtMaterialDesign
+ * Copyright (C) 2015 - 2017 GwtMaterialDesign
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/gwt/material/design/jquery/client/api/Functions.java
+++ b/src/main/java/gwt/material/design/jquery/client/api/Functions.java
@@ -19,7 +19,7 @@ package gwt.material.design.jquery.client.api;
  * #%L
  * GwtMaterial
  * %%
- * Copyright (C) 2015 - 2016 GwtMaterialDesign
+ * Copyright (C) 2015 - 2017 GwtMaterialDesign
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/gwt/material/design/jquery/client/api/JQuery.java
+++ b/src/main/java/gwt/material/design/jquery/client/api/JQuery.java
@@ -64,6 +64,9 @@ public class JQuery {
     // Plain Object Query
 
     @JsMethod(namespace = JsPackage.GLOBAL)
+    public static native JQueryElement $();
+
+    @JsMethod(namespace = JsPackage.GLOBAL)
     public static native JQueryElement $(Object plainObject);
 
     @JsMethod(namespace = JsPackage.GLOBAL)
@@ -189,6 +192,13 @@ public class JQuery {
     }
 
     // JQuery Global Functions
+
+    /**
+     * Get arbitrary data associated with the element.
+     * @return self {@link JQueryElement}
+     */
+    @JsMethod(namespace = "$")
+    public static native JQueryElement _data(JQueryElement element, String key);
 
     /**
      * Check to see if a DOM element is a descendant of another DOM element.

--- a/src/main/java/gwt/material/design/jquery/client/api/JQuery.java
+++ b/src/main/java/gwt/material/design/jquery/client/api/JQuery.java
@@ -19,7 +19,7 @@ package gwt.material.design.jquery.client.api;
  * #%L
  * GwtMaterial
  * %%
- * Copyright (C) 2015 - 2016 GwtMaterialDesign
+ * Copyright (C) 2015 - 2017 GwtMaterialDesign
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/gwt/material/design/jquery/client/api/JQueryElement.java
+++ b/src/main/java/gwt/material/design/jquery/client/api/JQueryElement.java
@@ -710,6 +710,13 @@ public class JQueryElement extends Node {
     public native JQueryElement css(Object properties);
 
     /**
+     * Get the computed style properties for the first element in the set of matched elements.
+     * @param propertyName A CSS property.
+     * @return {@link String} property value.
+     */
+    public native String css(String propertyName);
+
+    /**
      * Store arbitrary data associated with the matched elements.
      * @param key A string naming the piece of data to set.
      * @param value The new data value; this can be any Javascript type except undefined.

--- a/src/main/java/gwt/material/design/jquery/client/api/JQueryElement.java
+++ b/src/main/java/gwt/material/design/jquery/client/api/JQueryElement.java
@@ -19,7 +19,7 @@ package gwt.material.design.jquery.client.api;
  * #%L
  * GwtMaterial
  * %%
- * Copyright (C) 2015 - 2016 GwtMaterialDesign
+ * Copyright (C) 2015 - 2017 GwtMaterialDesign
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/gwt/material/design/jquery/client/api/KeyEvent.java
+++ b/src/main/java/gwt/material/design/jquery/client/api/KeyEvent.java
@@ -4,7 +4,7 @@ package gwt.material.design.jquery.client.api;
  * #%L
  * GwtMaterial
  * %%
- * Copyright (C) 2015 - 2016 GwtMaterialDesign
+ * Copyright (C) 2015 - 2017 GwtMaterialDesign
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/gwt/material/design/jquery/client/api/MouseEvent.java
+++ b/src/main/java/gwt/material/design/jquery/client/api/MouseEvent.java
@@ -4,7 +4,7 @@ package gwt.material.design.jquery.client.api;
  * #%L
  * GwtMaterial
  * %%
- * Copyright (C) 2015 - 2016 GwtMaterialDesign
+ * Copyright (C) 2015 - 2017 GwtMaterialDesign
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/gwt/material/design/jquery/client/api/Offset.java
+++ b/src/main/java/gwt/material/design/jquery/client/api/Offset.java
@@ -4,7 +4,7 @@ package gwt.material.design.jquery.client.api;
  * #%L
  * GwtMaterial
  * %%
- * Copyright (C) 2015 - 2016 GwtMaterialDesign
+ * Copyright (C) 2015 - 2017 GwtMaterialDesign
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/gwt/material/design/jquery/client/api/Offset.java
+++ b/src/main/java/gwt/material/design/jquery/client/api/Offset.java
@@ -27,7 +27,7 @@ import jsinterop.annotations.JsType;
 /**
  * @author Ben Dol
  */
-@JsType
+@JsType(isNative = true)
 public class Offset {
 
     @JsProperty

--- a/src/main/java/gwt/material/design/jquery/client/api/OrientationEvent.java
+++ b/src/main/java/gwt/material/design/jquery/client/api/OrientationEvent.java
@@ -4,7 +4,7 @@ package gwt.material.design.jquery.client.api;
  * #%L
  * GwtMaterial
  * %%
- * Copyright (C) 2015 - 2016 GwtMaterialDesign
+ * Copyright (C) 2015 - 2017 GwtMaterialDesign
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/gwt/material/design/jquery/client/api/OrientationEvent.java
+++ b/src/main/java/gwt/material/design/jquery/client/api/OrientationEvent.java
@@ -1,0 +1,71 @@
+package gwt.material.design.jquery.client.api;
+
+/*
+ * #%L
+ * GwtMaterial
+ * %%
+ * Copyright (C) 2015 - 2016 GwtMaterialDesign
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+
+import gwt.material.design.jscore.client.api.core.Element;
+import jsinterop.annotations.JsProperty;
+import jsinterop.annotations.JsType;
+
+/**
+ * MouseEvent for JQuery.
+ * 
+ * @author Ben Dol
+ */
+@JsType(isNative=true)
+public class OrientationEvent extends KeyEvent {
+
+    @JsProperty
+    public native int getPageX();
+
+    @JsProperty
+    public native int getPageY();
+
+    @JsProperty
+    public native int getClientX();
+
+    @JsProperty
+    public native int getClientY();
+
+    @JsProperty
+    public native int getOffsetX();
+
+    @JsProperty
+    public native int getOffsetY();
+
+    @JsProperty
+    public native int getScreenX();
+
+    @JsProperty
+    public native int getScreenY();
+
+    @JsProperty
+    public native Element getTarget();
+
+    @JsProperty
+    public native Element getToElement();
+
+    @JsProperty
+    public native int getButton();
+
+    @JsProperty
+    public native int getButtons();
+}

--- a/src/main/java/gwt/material/design/jquery/client/api/Promise.java
+++ b/src/main/java/gwt/material/design/jquery/client/api/Promise.java
@@ -19,7 +19,7 @@ package gwt.material.design.jquery.client.api;
  * #%L
  * GwtMaterial
  * %%
- * Copyright (C) 2015 - 2016 GwtMaterialDesign
+ * Copyright (C) 2015 - 2017 GwtMaterialDesign
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/gwt/material/design/jscore/JSCore.gwt.xml
+++ b/src/main/java/gwt/material/design/jscore/JSCore.gwt.xml
@@ -3,7 +3,7 @@
   #%L
   GwtMaterial
   %%
-  Copyright (C) 2015 - 2016 GwtMaterialDesign
+  Copyright (C) 2015 - 2017 GwtMaterialDesign
   %%
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.


### PR DESCRIPTION
> Ready for 2.0-rc6 release.

- Upgrade GWT Version to 2.8.1
- Implement '_data' method. (Thanks @BenDol )
- Fix issues with the Offset object. (Thanks @BenDol )
- Add missing 'css' method. (Thanks @BenDol )
- Upgrade Java version from 1.7 to 1.8




